### PR TITLE
Update loginGJAccount.md to reflect password change

### DIFF
--- a/docs/endpoints/accounts/loginGJAccount.md
+++ b/docs/endpoints/accounts/loginGJAccount.md
@@ -11,7 +11,7 @@ This endpoint is used to log into a players Geometry Dash account.
 | ---------- | ----------------------------------------------------------------------------------------------------- | -------- |
 | `udid`     | The user's [UDID](/topics/encryption/id.md#udid)                                                      | Yes      |
 | `userName` | The username for the account the player is trying to log into                                         | Yes      |
-| `gjp2`     | The password of the account the player is trying to log into with [GJP2](/topics/gjp.md) encryptio    | Yes      |
+| `gjp2`     | The password of the account the player is trying to log into, encoded with [GJP2](/topics/gjp.md)     | Yes      |
 | `secret`   | [Account Secret](/reference/secrets.md): `Wmfv3899gc9`                                                | Yes      |
 | `sID`      | The player's Steam ID                                                                                 |          |
 

--- a/docs/endpoints/accounts/loginGJAccount.md
+++ b/docs/endpoints/accounts/loginGJAccount.md
@@ -11,7 +11,7 @@ This endpoint is used to log into a players Geometry Dash account.
 | ---------- | ----------------------------------------------------------------------------------------------------- | -------- |
 | `udid`     | The user's [UDID](/topics/encryption/id.md#udid)                                                      | Yes      |
 | `userName` | The username for the account the player is trying to log into                                         | Yes      |
-| `password` | The plaintext password for the account the player is trying to log into                               | Yes      |
+| `gjp2`     | The password of the account the player is trying to log into with [GJP2](/topics/gjp.md) encryptio    | Yes      |
 | `secret`   | [Account Secret](/reference/secrets.md): `Wmfv3899gc9`                                                | Yes      |
 | `sID`      | The player's Steam ID                                                                                 |          |
 


### PR DESCRIPTION
As noted while using the GDIntercept mod for Geode, the geometry dash client now sends the GJP2 on the login flow instead of the plaintext password.

I'm not sure if this change also applies to registering accounts or even other endpoints, but as far as i'm aware, login was affected.