### PR TITLE
Change body encryption to XOR

### DIFF
--- a/docs/endpoints/socials/uploadGJMessage20.md
+++ b/docs/endpoints/socials/uploadGJMessage20.md
@@ -10,10 +10,10 @@ Sends a message to a user
 | `gjp2`          | The [GJP2](/topics/gjp.md) of the user sending the message                            | Yes      |
 | `toAccountID`   | Account ID of the user retrieving the message                                         | Yes      |
 | `subject`       | The subject of the message, converted to [URL-safe base64](/topics/encryption/base64) | Yes      |
-| `body`          | The body of the message, converted to [URL-safe base64](/topics/encryption/base64)    | Yes      |
-| `secret`        | [Common Secret](/reference/secrets.md): `Wmfd2893gb7`                                    | Yes      |
+| `body`          | The body of the message, [Xor'd](/topics/encryption/xor) with a key of `14251` and then encoded in [URL-safe base64](/topics/encryption/base64)    | Yes      |
+| `secret`        | [Common Secret](/reference/secrets.md): `Wmfd2893gb7`                                 | Yes      |
 | `gameVersion`   | 22                                                                                    |          |
-| `binaryVersion` | 42                                                                                    |          |
+| `binaryVersion` | 47                                                                                    |          |
 | `gdw`           | 0                                                                                     |          |
 
 ## Response
@@ -29,20 +29,23 @@ Sends a message to a user
 ```py
 import requests
 
+def xor_encrypt(msg, key="14251"):
+    return "".join(chr(ord(c) ^ ord(key[i % len(key)])) for i, c in enumerate(msg))
+
 data = {
-    "gameVersion": 21,
-    "binaryVersion": 35,
+    "gameVersion": 22,
+    "binaryVersion": 47,
     "gdw": 0,
 	"accountID": 173831, # This is DevExit's account ID
 	"gjp2": "*******", # This would be DevExit's password encoded with GJP2 encryption
     "toAccountID": 173831, # Yes! You can send messages to yourself
     "subject": base64.b64encode(b"You're dumb lol").decode(),
-    "body": base64.b64encode(b"Mhm yep you're p dumb lmao").decode(),
+    "body": base64.b64encode(xor_encrypt("Mhm yep you're p dumb lmao").encode()).decode(),
     "secret": "Wmfd2893gb7",
 }
 
 r = requests.post('https://www.boomlings.com/database/uploadGJMessage20.php', data=data)
-print(req.text)
+print(r.text)
 ```
 
 **Response**


### PR DESCRIPTION
2.2 now uses XOR on uploadGJMessage20.php as well.

Simply encoding with URL-Safe Base64 would lead to an unreadable, invalid message. You must first encode it with XOR key `14251`.