### PR TITLE
Update enumerations.md

### DIFF
--- a/docs/resources/client/level-components/color-string.md
+++ b/docs/resources/client/level-components/color-string.md
@@ -14,7 +14,7 @@ The color entries have the following properties:
 | 1   | FromColourRed       | **Integer**                         | the Red component of the color             |
 | 2   | FromColourGreen     | **Integer**                         | the Green component of the color           |
 | 3   | FromColourBlue      | **Integer**                         | the Blue component of the color            |
-| 4   | PlayerColor         | **[Player Color](/resources/client/level-components/enumerations.md)** | the Player Color that the color is copying |
+| 4   | PlayerColor         | **[Player Color](/resources/client/level-components/enumerations.md#player-color)** | the Player Color that the color is copying |
 | 5   | Blending            | **Bool**                            | the Blending property of the color         |
 | 6   | ColourChannelIndex  | **Integer**                         | the Color Channel ID of the color          |
 | 7   | FromOpacity         | **Float**                           | the Opacity property of the color          |

--- a/docs/resources/client/level-components/enumerations.md
+++ b/docs/resources/client/level-components/enumerations.md
@@ -82,4 +82,11 @@ Here you will find the enumerations that are related to the level string.
 | 1   | Larger  |
 | 2   | Smaller |
 
+## Player Color
+
+| Key | Name    |
+| --- | ------- |
+| -1  | None    |
+| 1   | 1st     |
+| 2   | 2nd     |
 


### PR DESCRIPTION
Implemented Player Color
The path Color String → Color Properties → Player Color was referencing an enum, but the appropriate enum was missing at that link. I have since added it.