### PR TITLE
A few miscellaneous fixes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ aside: true
 - `binaryVersion`: `46` (2.208), `47` (2.2081)
 - new getGJScores20 param: [`stat`](/endpoints/users/getGJScores20#:~:text=stat,Default%3A%200.) which orders the requested leaderboard by a statistic
 - new updateGJAccSettings20 params: [`instagram`, `tiktok`, `discord`, `custom`](/endpoints/accounts/updateGJAccSettings20#:~:text=instagram,time%20authentication%20token) and the corresponding user keys [58-61](/resources/server/user#:~:text=58*,time%20authentication%20token)
+- user key `51` (glow color) is now always included in responses
 - new getGJGauntlets21 param: [`vkey`](/endpoints/levels/getGJGauntlets21#:~:text=vkey,which%20is%202.2080\))
 - new [getGJLevelScores211](/endpoints/levels/getGJLevelScores211#:~:text=s11,The%20level%20version) and [getGJLevelScoresPlat](/endpoints/levels/getGJLevelScoresPlat#:~:text=s11,The%20level%20version) params: `s11`-`s20`
 - the [Level Leaderboard CHK](topics/encryption/chk#level-leaderboard) is now more secure ✨

--- a/docs/endpoints/accounts/syncGJAccountNew.md
+++ b/docs/endpoints/accounts/syncGJAccountNew.md
@@ -31,9 +31,9 @@ A list of values, separated by semicolons `;`:
 
 - binaryVersion sent when saving
 
-- a list of rated levels separated by commas `,`, in the format `[levelID],[stars]`, compressed with deflate and a random string of *20* characters at the front and back
+- a list of rated levels separated by commas `,`, in the format `[levelID],[stars]`, compressed with deflate, URL safe Base64 encoded, and a random string of *20* characters at the front and back
 
-- a list of [map pack objects](/resources/server/mappack.md) separated by pipes `|`, with keys 1, 3, 4 and 5, compressed with deflate and a random string of *20* characters at the front and back
+- a list of [map pack objects](/resources/server/mappack.md) separated by pipes `|`, with keys 1, 3, 4 and 5, compressed with deflate, URL safe Base64 encoded, and a random string of *20* characters at the front and back
 
 ## Example
 

--- a/docs/endpoints/comments/uploadGJComment21.md
+++ b/docs/endpoints/comments/uploadGJComment21.md
@@ -12,8 +12,8 @@ Uploads a comment to a user level.
 | `comment`       | The comment, converted to [URL-safe base64](/topics/encryption/base64) | Yes      | <!--a-->
 | `secret`        | <ParamDesc name="secret" type="common"/> | Yes      | <!--a-->
 | `levelID`       | The ID of the level to comment on. If commenting on a list, the ID should be negative | Yes      | <!--a-->
-| `percent`       | The level percentage shown on the comment | Yes      | <!--o: not sent when zero-->
-| [`chk`](/topics/encryption/chk) | `userName` + `comment` + `levelID` + `percent` | Yes      | <!--a-->
+| [`chk`](/topics/encryption/chk#comment) | `userName` + `comment` + `levelID` + `percent` + `0` | Yes      | <!--a-->
+| `percent`       | The level percentage shown on the comment as an integer. Only sent if percentage is not 0 |          | <!--o: not sent when zero-->
 | `gameVersion`   | <ParamDesc name="gameVersion"/> |          | <!--a-->
 | `binaryVersion` | <ParamDesc name="binaryVersion"/> |          | <!--a-->
 | `udid`          | <ParamDesc name="udid"/> |          | <!--a-->
@@ -35,7 +35,7 @@ import requests
 
 # With this code, DevExit is posting the comment "Hello from the GDDocs!" to 62687277
 
-chk = generate_chk(key="29481", values=["devexit", "SGVsbG8gZnJvbSB0aGUgR0REb2NzIQ==", 62687277, 69], salt="0xPT6iUrtws0J")
+chk = generate_chk(key="29481", values=["devexit", "SGVsbG8gZnJvbSB0aGUgR0REb2NzIQ==", 62687277, 69, 0], salt="xPT6iUrtws0J")
 # These values can be found in the XOR and CHK pages
 
 data = {

--- a/docs/endpoints/comments/uploadGJComment21.md
+++ b/docs/endpoints/comments/uploadGJComment21.md
@@ -12,7 +12,7 @@ Uploads a comment to a user level.
 | `comment`       | The comment, converted to [URL-safe base64](/topics/encryption/base64) | Yes      | <!--a-->
 | `secret`        | <ParamDesc name="secret" type="common"/> | Yes      | <!--a-->
 | `levelID`       | The ID of the level to comment on. If commenting on a list, the ID should be negative | Yes      | <!--a-->
-| [`chk`](/topics/encryption/chk#comment) | `userName` + `comment` + `levelID` + `percent` + `0` | Yes      | <!--a-->
+| `chk`           | [Comments CHK](/topics/encryption/chk#comment) | Yes      | <!--a-->
 | `percent`       | The level percentage shown on the comment as an integer. Only sent if percentage is not 0 |          | <!--o: not sent when zero-->
 | `gameVersion`   | <ParamDesc name="gameVersion"/> |          | <!--a-->
 | `binaryVersion` | <ParamDesc name="binaryVersion"/> |          | <!--a-->

--- a/docs/resources/server/friendrequest.md
+++ b/docs/resources/server/friendrequest.md
@@ -35,6 +35,7 @@ A list of all known keys can be found in the table below
 | 35  | message | **String** | The friend request's message, encoded in [base64](/topics/encryption/base64.md)
 | 37  | age | **String** | How long ago the friend request was sent (e.g. "2 months")
 | 41  | newFriendRequest | **Bool** | if the friend request is new
+| 51  | color3 | **Integer** | The player's glow color |
 
 #### Trivia
 

--- a/docs/resources/server/leaderboardscore.md
+++ b/docs/resources/server/leaderboardscore.md
@@ -55,6 +55,7 @@ A list of all known keys can be found in the table below
 | 15  | special | **Integer** | functions the same as glow however it returns a 2 rather than a 1
 | 16  | accountID | **Integer** | The user's account ID. **This is different than the player ID**
 | 42  | age | **String** | How long ago the score was set (e.g. "2 months")
+| 51  | color3 | **Integer** | The player's glow color |
 
 ### Top Leaderboard Score Structure
 

--- a/docs/resources/server/leaderboardscore.md
+++ b/docs/resources/server/leaderboardscore.md
@@ -76,6 +76,7 @@ A list of all known keys can be found in the table below
 | 16  | accountID | **Integer** | The user's account ID. **This is different than the player ID**
 | 17  | userCoins | **Integer** | The amount of user coins the player has
 | 46  | diamonds | **Integer** | The amount of diamonds the player has
+| 51  | color3 | **Integer** | The player's glow color |
 | 52  | moons | **Integer** | The amount of moons the player has
 
 ### Trivia

--- a/docs/topics/encryption/xor.md
+++ b/docs/topics/encryption/xor.md
@@ -10,12 +10,13 @@ When needed, Geometry Dash iterates through every byte of the data and applies t
 
 ## Examples
 
-Below are pseudocode examples of the algorithms used
+Below are examples of the algorithms used
 
 <!-- tabs:start -->
 
 ### **Singular**
 
+#### Pseudocode
 ```js
 result = "";
 for (i = 0; i < input.length; i++) {
@@ -24,8 +25,18 @@ for (i = 0; i < input.length; i++) {
 }
 ```
 
+#### Python
+```py
+def xor(input: str, key: int):
+    return "".join(
+        chr(ord(char) ^ key)
+        for char in input
+    )
+```
+
 ### **Cycle**
 
+#### Pseudocode
 ```js
 result = "";
 for (i = 0; i < input.length; i++) {
@@ -33,6 +44,17 @@ for (i = 0; i < input.length; i++) {
   xKey = key[i % key.length].toByte();
   result += (byte ^ xKey).toChar();
 }
+```
+
+#### Python
+```py
+def cyclic_xor(input: str, key: int):
+    key_str = str(key)
+    
+    return "".join(
+        chr(ord(char) ^ ord(key_str[i % len(key_str)]))
+        for i, char in enumerate(input)
+    )
 ```
 
 <!-- tabs:end -->


### PR DESCRIPTION
- Added color3 to Top Leaderboard Score, as I noticed its key being returned
- Added Python code examples to the xor cipher page
- Updated uploadGJComment; made percent optional, and for consistency with the chk page, moved the `0` from the salt to the chk values
- Fixed syncGJAccount; the levels and map pack objects are b64 encoded after compression