### PR TITLE
Added "Level Length" to enumerations.md

### DIFF
--- a/docs/resources/client/level-components/enumerations.md
+++ b/docs/resources/client/level-components/enumerations.md
@@ -90,3 +90,13 @@ Here you will find the enumerations that are related to the level string.
 | 1   | 1st     |
 | 2   | 2nd     |
 
+## Level Length
+
+| Key       | Name           |
+| --------- | -------------- |
+| 0 (None)  | Tiny           |
+| 1         | Short          |
+| 2         | Medium         |
+| 3         | Long           |
+| 4         | XL             |
+| 5         | Platformer     |


### PR DESCRIPTION
A table of level length constants has been added, referenced by
[Client -> Saved Level -> Level Structure -> k23](https://boomlings.dev/resources/client/level#level-data)

The code used to obtain the values:
```python
import base64
import zlib
import re

INT_CODE_PATTERN = r"<k>k23</k><i>(.*?)</i>"
STR_CODE_PATTERN = r"<k>k2</k><s>(.*?)</s>"

def decode_level(level_data: str, is_official_level: bool) -> str:
    if is_official_level:
        level_data = 'H4sIAAAAAAAAA' + level_data
    base64_decoded = base64.urlsafe_b64decode(level_data.encode())
    # window_bits = 15 | 32 will autodetect gzip or not
    decompressed = zlib.decompress(base64_decoded, 15 | 32)
    return decompressed.decode()

def get_len(path: str):
    content = open(path, "r").read()

    match = re.search(INT_CODE_PATTERN, content)
    if match:
        code_int = match.group(1)
    else:
        code_int = None

    match = re.search(STR_CODE_PATTERN, content)
    if match:
        code_str = match.group(1)
    else:
        code_str = None

    code_int_display = str(code_int) if code_int is not None else "None"
    code_str_display = str(code_str) if code_str is not None else "None"
    
    print(f"{path:<22} -> k23: {code_int_display:<4} k2: {code_str_display}")

get_len("levels/tiny.gmd")
get_len("levels/short.gmd")
get_len("levels/medium.gmd")
get_len("levels/long.gmd")
get_len("levels/xl.gmd")
get_len("levels/platformer.gmd")
```

Output:
```text
levels/tiny.gmd        -> k23: None k2: tiny
levels/short.gmd       -> k23: 1    k2: short
levels/medium.gmd      -> k23: 2    k2: medium
levels/long.gmd        -> k23: 3    k2: long
levels/xl.gmd          -> k23: 4    k2: xl
levels/platformer.gmd  -> k23: 5    k2: platformer
```