### PR TITLE
Fix inverted mapPack object mapping

### DIFF
--- a/docs/resources/server/mappack.md
+++ b/docs/resources/server/mappack.md
@@ -27,8 +27,8 @@ A list of all known keys can be found in the table below
 | 4   | stars	   | **Integer** | How many stars the map pack should give
 | 5   | coins	   | **Integer** | How many coins the map pack should give
 | 6   | [difficulty](/resources/client/level-components/enumerations.md) | **Integer** | Difficulty ranging from `0->10`
-| 7   | textColor | **String** | RGB color for the title text separated by `,`
-| 8   | barColor  | **String** | RGB color for the completion bar separated by `,`
+| 7   | barColor | **String** | RGB color for the completion bar separated by `,`
+| 8   | textColor  | **String** | RGB color for the title text separated by `,`
 
 
 ### Trivia


### PR DESCRIPTION
In the current version, textColor is mapped to key 7 and barColor is mapped to key 8. After some testing with a GDPS, i can confirm that the correct order is: key 7: barColor; key 8: textColor.